### PR TITLE
Minor header adjustments

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,39 +1,13 @@
 <template>
   <div class="min-h-screen flex flex-col "><!-- Main application wrapper -->
-    <header
-    style="backdrop-filter: blur(8px); background-color: color-mix(in srgb, var(--bulma-navbar-background-color) 80%, transparent);"
-    class="navbar is-fixed-top" role="navigation" aria-label="main navigation">
-
-      <div class="navbar-brand">
-        <RouterLink class="navbar-item has-text-weight-bold p-0" to="/" >
-          <img src="@/assets/ViossaFlagRect.svg" alt="Viossa flag" style="height: var(--bulma-navbar-height); max-height: none;" />
-        </RouterLink> 
-
-        <div class="navbar-item">
-          <button 
-            type="button"
-            @click="toggleBurger()"
-            :class="`button is-link is-hoverable is-hidden-desktop ${burgerOpen ? 'is-active' : ''}`" aria-label="menu"
-            :aria-expanded="`${burgerOpen ? 'true' : 'false'}`">
-            <span class="bx bx-burger"></span>
-          </button>
-        </div>
-      </div>
-      
-      <div :class="`navbar-menu ${burgerOpen ? 'is-active' : ''}`">
-        <div class="navbar-start">
-          <RouterLink class="navbar-item" to="/">What is Viossa?</RouterLink>
-          <RouterLink class="navbar-item" to="/resources">Resources</RouterLink>
-        </div>
-      </div>
-
-    </header style="backdrop-filter: blur(8px); background-color: oklab(80% var(--bulma-navbar-background-color) transparent);">
+    <Header />
     <RouterView />
   </div>
 </template>
 
 <script setup lang="ts">
 import './assets/style.scss'
+import Header from './components/organisms/Header.vue'
 import { ref, type Ref } from 'vue'
 
 const burgerOpen: Ref<Boolean> = ref<Boolean>(false);

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,13 @@
 <template>
   <div class="min-h-screen flex flex-col "><!-- Main application wrapper -->
-    <nav class="navbar is-fixed-top" role="navigation" aria-label="main navigation">
+    <header
+    style="backdrop-filter: blur(8px); background-color: color-mix(in srgb, var(--bulma-navbar-background-color) 80%, transparent);"
+    class="navbar is-fixed-top" role="navigation" aria-label="main navigation">
 
       <div class="navbar-brand">
-        <RouterLink class="navbar-item has-text-weight-bold" to="/"><img src="@/assets/ViossaFlagRect.svg" alt=""/></RouterLink>
+        <RouterLink class="navbar-item has-text-weight-bold p-0" to="/" >
+          <img src="@/assets/ViossaFlagRect.svg" alt="Viossa flag" style="height: var(--bulma-navbar-height); max-height: none;" />
+        </RouterLink> 
 
         <div class="navbar-item">
           <button 
@@ -23,7 +27,7 @@
         </div>
       </div>
 
-    </nav>
+    </header style="backdrop-filter: blur(8px); background-color: oklab(80% var(--bulma-navbar-background-color) transparent);">
     <RouterView />
   </div>
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,11 +8,4 @@
 <script setup lang="ts">
 import './assets/style.scss'
 import Header from './components/organisms/Header.vue'
-import { ref, type Ref } from 'vue'
-
-const burgerOpen: Ref<Boolean> = ref<Boolean>(false);
-
-function toggleBurger(): void {
-  burgerOpen.value = !burgerOpen.value;
-}
 </script>

--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -1,26 +1,43 @@
 @use "./bulma.css";
 
 * {
-  --bulma-primary-h: 196deg;
-  --bulma-primary-l: 50%;
-  --bulma-primary-s: 100%;
+	--bulma-primary-h: 196deg;
+	--bulma-primary-l: 50%;
+	--bulma-primary-s: 100%;
 
-  --bulma-link-h: 293deg;
-  --bulma-link-l: 50%;
-  --bulma-link-s: 45%;
+	--bulma-link-h: 293deg;
+	--bulma-link-l: 50%;
+	--bulma-link-s: 45%;
 
-  --bulma-warning-h: 31deg;
-  --bulma-warning-l: 75%;
-  --bulma-warning-s: 100%;
+	--bulma-warning-h: 31deg;
+	--bulma-warning-l: 75%;
+	--bulma-warning-s: 100%;
 
-  --bulma-info-h: 90deg;
-  --bulma-info-l: 50%;
-  --bulma-info-s: 45%;
+	--bulma-info-h: 90deg;
+	--bulma-info-l: 50%;
+	--bulma-info-s: 45%;
 
-  
+	--bulma-family-primary:
+		Nunito, Inter, SF Pro, Segoe UI, Roboto, Oxygen, Ubuntu, Helvetica Neue,
+		Helvetica, Arial, sans-serif;
+	--bulma-family-secondary:
+		Nunito, Inter, SF Pro, Segoe UI, Roboto, Oxygen, Ubuntu, Helvetica Neue,
+		Helvetica, Arial, sans-serif;
+	--bulma-body-family:
+		Nunito, Inter, SF Pro, Segoe UI, Roboto, Oxygen, Ubuntu, Helvetica Neue,
+		Helvetica, Arial, sans-serif;
+}
 
+#viosa-flag {
+	height: var(--bulma-navbar-height);
+	max-height: none;
+}
 
-  --bulma-family-primary: Nunito,Inter,SF Pro,Segoe UI,Roboto,Oxygen,Ubuntu,Helvetica Neue,Helvetica,Arial,sans-serif;
-  --bulma-family-secondary: Nunito,Inter,SF Pro,Segoe UI,Roboto,Oxygen,Ubuntu,Helvetica Neue,Helvetica,Arial,sans-serif;
-  --bulma-body-family: Nunito,Inter,SF Pro,Segoe UI,Roboto,Oxygen,Ubuntu,Helvetica Neue,Helvetica,Arial,sans-serif;
-};
+header {
+	backdrop-filter: blur(8px);
+	background-color: color-mix(
+		in srgb,
+		var(--bulma-navbar-background-color) 80%,
+		transparent
+	);
+}

--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -28,7 +28,7 @@
 		Helvetica, Arial, sans-serif;
 }
 
-#viosa-flag {
+#viossa-flag {
 	height: var(--bulma-navbar-height);
 	max-height: none;
 }

--- a/src/components/organisms/Header.vue
+++ b/src/components/organisms/Header.vue
@@ -27,3 +27,13 @@
 
     </header style="backdrop-filter: blur(8px); background-color: oklab(80% var(--bulma-navbar-background-color) transparent);">
 </template>
+
+<script setup lang="ts">
+  import { ref, type Ref } from 'vue'
+
+  const burgerOpen: Ref<Boolean> = ref<Boolean>(false);
+
+  function toggleBurger(): void {
+    burgerOpen.value = !burgerOpen.value;
+  }
+</script>

--- a/src/components/organisms/Header.vue
+++ b/src/components/organisms/Header.vue
@@ -1,11 +1,10 @@
 <template>
   <header
-    style="backdrop-filter: blur(8px); background-color: color-mix(in srgb, var(--bulma-navbar-background-color) 80%, transparent);"
     class="navbar is-fixed-top" role="navigation" aria-label="main navigation">
 
       <div class="navbar-brand">
         <RouterLink class="navbar-item has-text-weight-bold p-0" to="/" >
-          <img src="@/assets/ViossaFlagRect.svg" alt="Viossa flag" style="height: var(--bulma-navbar-height); max-height: none;" />
+          <img src="@/assets/ViossaFlagRect.svg" id="viossa-flag" alt="Viossa flag" />
         </RouterLink> 
 
         <div class="navbar-item">

--- a/src/components/organisms/Header.vue
+++ b/src/components/organisms/Header.vue
@@ -1,0 +1,30 @@
+<template>
+  <header
+    style="backdrop-filter: blur(8px); background-color: color-mix(in srgb, var(--bulma-navbar-background-color) 80%, transparent);"
+    class="navbar is-fixed-top" role="navigation" aria-label="main navigation">
+
+      <div class="navbar-brand">
+        <RouterLink class="navbar-item has-text-weight-bold p-0" to="/" >
+          <img src="@/assets/ViossaFlagRect.svg" alt="Viossa flag" style="height: var(--bulma-navbar-height); max-height: none;" />
+        </RouterLink> 
+
+        <div class="navbar-item">
+          <button 
+            type="button"
+            @click="toggleBurger()"
+            :class="`button is-link is-hoverable is-hidden-desktop ${burgerOpen ? 'is-active' : ''}`" aria-label="menu"
+            :aria-expanded="`${burgerOpen ? 'true' : 'false'}`">
+            <span class="bx bx-burger"></span>
+          </button>
+        </div>
+      </div>
+      
+      <div :class="`navbar-menu ${burgerOpen ? 'is-active' : ''}`">
+        <div class="navbar-start">
+          <RouterLink class="navbar-item" to="/">What is Viossa?</RouterLink>
+          <RouterLink class="navbar-item" to="/resources">Resources</RouterLink>
+        </div>
+      </div>
+
+    </header style="backdrop-filter: blur(8px); background-color: oklab(80% var(--bulma-navbar-background-color) transparent);">
+</template>


### PR DESCRIPTION
Made some quick changes to the header to make it look nicer:
1. Moved the header into it's own component file.
2. Added a slight blur and transparency to the backdrop of the header.
3. Made the flag fill the whole height of the header.

The css for some parts was a little rough so it would be nice to add something more customizable (I've used tailwind a bit and it looks good) and then I can make it look better.

![Before](https://github.com/user-attachments/assets/7a84ddc7-6c68-44fe-b8e2-fc36125f7eba) Before

![After](https://github.com/user-attachments/assets/7b66e4fa-ee84-4d19-be17-baa884568638) After
